### PR TITLE
Add subtle wave background

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,8 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Jonan Harrewijn</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="static/style.css">
 </head>
-<body class="bg-gray-100 text-gray-800 font-sans">
+<body>
   
 
 <!-- Landing Section -->

--- a/docs/static/style.css
+++ b/docs/static/style.css
@@ -1,0 +1,10 @@
+body {
+  /* Wave pattern background */
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27100%27%20height%3D%2740%27%20viewBox%3D%270%200%20100%2040%27%3E%3Cpath%20fill%3D%27%2523ffffff%27%20fill-opacity%3D%270.3%27%20d%3D%27M0%2020%20Q%2025%2010%2050%2020%20T100%2020%20V40%20H0%20Z%27/%3E%3C/svg%3E"),
+    linear-gradient(to bottom right, #e0f2fe, #c7d2fe);
+  background-size: 200px 80px, cover;
+  background-repeat: repeat, no-repeat;
+  background-attachment: fixed;
+  color: #1f2937; /* text-gray-800 */
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,10 @@
+body {
+  /* Wave pattern background */
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27100%27%20height%3D%2740%27%20viewBox%3D%270%200%20100%2040%27%3E%3Cpath%20fill%3D%27%2523ffffff%27%20fill-opacity%3D%270.3%27%20d%3D%27M0%2020%20Q%2025%2010%2050%2020%20T100%2020%20V40%20H0%20Z%27/%3E%3C/svg%3E"),
+    linear-gradient(to bottom right, #e0f2fe, #c7d2fe);
+  background-size: 200px 80px, cover;
+  background-repeat: repeat, no-repeat;
+  background-attachment: fixed;
+  color: #1f2937; /* text-gray-800 */
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,8 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Jonan Harrewijn</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="static/style.css">
 </head>
-<body class="bg-gray-100 text-gray-800 font-sans">
+<body>
   {% block content %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- style the page with a gentle wave pattern
- link the stylesheet in the base template
- rebuild generated docs

## Testing
- `python3 build.py`


------
https://chatgpt.com/codex/tasks/task_e_6866461cf3208321a84cda95b9a0f739