### PR TITLE
Refine subtle pattern and lighten section backgrounds

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
   
 
 <!-- Landing Section -->
-<section class="min-h-[75vh] flex flex-col md:flex-row items-center justify-center bg-gradient-to-br from-slate-900 to-slate-700 text-white px-6 py-16 animate-fade-in" style="animation-delay: 0.2s;">
+<section class="min-h-[75vh] flex flex-col md:flex-row items-center justify-center bg-gradient-to-br from-white to-blue-50 text-gray-800 px-6 py-16 animate-fade-in" style="animation-delay: 0.2s;">
   <div class="w-full md:w-1/2 flex justify-center mb-10 md:mb-0">
     <img src="static/images/profile.jpg" alt="My Photo" class="w-48 h-48 md:w-56 md:h-56 rounded-full shadow-2xl border-4 border-white object-cover" />
   </div>
@@ -20,39 +20,39 @@
       Hi, I'm Jonan Harrewijn
     </h1>
     <p class="text-lg md:text-xl mb-2 max-w-xl">
-      <span class="text-gray-300">I’m a</span>
-      <span id="typing" class="font-semibold text-white"></span>
+      <span class="text-gray-500">I’m a</span>
+      <span id="typing" class="font-semibold text-blue-700"></span>
     </p>
-    <p class="text-base text-gray-300 max-w-xl leading-relaxed">
+    <p class="text-base text-gray-700 max-w-xl leading-relaxed">
       I build modern data platforms, dashboards, and data products using Microsoft Fabric, Azure, Power BI and Python. I help organizations turn raw data into strategic insight — fast, scalable, and secure.
     </p>
-    <div class="grid grid-cols-2 md:grid-cols-5 gap-6 mt-8 text-gray-300 text-xs md:text-sm">
+    <div class="grid grid-cols-2 md:grid-cols-5 gap-6 mt-8 text-gray-700 text-xs md:text-sm">
       <div class="flex flex-col items-center">
-        <svg class="h-8 w-8 mb-2 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
+        <svg class="h-8 w-8 mb-2 text-blue-700" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.737 5.1a3.375 3.375 0 0 1 2.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 0 1 .9 2.7m0 0a3 3 0 0 1-3 3m0 3h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Zm-3 6h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Z" />
         </svg>
         <span class="text-center">Data Platform Architect</span>
       </div>
       <div class="flex flex-col items-center">
-        <svg class="h-8 w-8 mb-2 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
+        <svg class="h-8 w-8 mb-2 text-blue-700" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
         </svg>
         <span class="text-center">Power BI Expert</span>
       </div>
       <div class="flex flex-col items-center">
-        <svg class="h-8 w-8 mb-2 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
+        <svg class="h-8 w-8 mb-2 text-blue-700" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
         </svg>
         <span class="text-center">ETL &amp; Pipeline Dev</span>
       </div>
       <div class="flex flex-col items-center">
-        <svg class="h-8 w-8 mb-2 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
+        <svg class="h-8 w-8 mb-2 text-blue-700" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z" />
         </svg>
         <span class="text-center">DevOps for Data</span>
       </div>
       <div class="flex flex-col items-center">
-        <svg class="h-8 w-8 mb-2 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
+        <svg class="h-8 w-8 mb-2 text-blue-700" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
         </svg>
         <span class="text-center">Data Governance Lead</span>
@@ -154,10 +154,10 @@
 
 
 <!-- Identity Section -->
-<section class="bg-slate-800 text-white py-16 px-6">
+<section class="bg-gradient-to-br from-white to-blue-50 text-gray-800 py-16 px-6">
   <div class="max-w-3xl mx-auto text-center space-y-4">
     <h2 class="text-2xl font-bold">Who I Am</h2>
-    <p class="text-base text-gray-300">Passionate about turning data into stories. I love clean design and helping organizations see the people behind the numbers.</p>
+    <p class="text-base text-gray-700">Passionate about turning data into stories. I love clean design and helping organizations see the people behind the numbers.</p>
   </div>
 </section>
 
@@ -339,15 +339,15 @@
 </section>
 
 <!-- Footer -->
-<footer class="bg-slate-800 text-white py-8 mt-16">
+<footer class="bg-gradient-to-br from-white to-blue-50 text-gray-800 py-8 mt-16">
   <div class="max-w-4xl mx-auto px-6 text-center">
     <p class="text-lg font-semibold mb-2">Let's connect</p>
     <p class="text-sm mb-4">
       📧 <a href="mailto:jonanharrewijn@hotmail.com" class="underline hover:text-blue-400">jonanharrewijn@hotmail.com</a><br>
       📱 <a href="tel:+31641270903" class="hover:text-blue-400">+31 6 41270903</a>
     </p>
-    <hr class="my-4 border-gray-600" />
-    <p class="text-xs text-gray-400">
+    <hr class="my-4 border-gray-300" />
+    <p class="text-xs text-gray-600">
       © 2025 Jonan Harrewijn. Built with Python, Jinja2 & 💙
     </p>
   </div>

--- a/docs/static/style.css
+++ b/docs/static/style.css
@@ -1,9 +1,15 @@
 body {
-  /* Wave pattern background */
-  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27100%27%20height%3D%2740%27%20viewBox%3D%270%200%20100%2040%27%3E%3Cpath%20fill%3D%27%2523ffffff%27%20fill-opacity%3D%270.3%27%20d%3D%27M0%2020%20Q%2025%2010%2050%2020%20T100%2020%20V40%20H0%20Z%27/%3E%3C/svg%3E"),
-    linear-gradient(to bottom right, #e0f2fe, #c7d2fe);
-  background-size: 200px 80px, cover;
-  background-repeat: repeat, no-repeat;
+  /* Subtle line pattern background */
+  background-color: #ffffff;
+  background-image: repeating-linear-gradient(
+      45deg,
+      #e5e5e5 0,
+      #e5e5e5 1px,
+      transparent 1px,
+      transparent 8px
+    );
+  background-size: auto;
+  background-repeat: repeat;
   background-attachment: fixed;
   color: #1f2937; /* text-gray-800 */
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;

--- a/static/style.css
+++ b/static/style.css
@@ -1,9 +1,15 @@
 body {
-  /* Wave pattern background */
-  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27100%27%20height%3D%2740%27%20viewBox%3D%270%200%20100%2040%27%3E%3Cpath%20fill%3D%27%2523ffffff%27%20fill-opacity%3D%270.3%27%20d%3D%27M0%2020%20Q%2025%2010%2050%2020%20T100%2020%20V40%20H0%20Z%27/%3E%3C/svg%3E"),
-    linear-gradient(to bottom right, #e0f2fe, #c7d2fe);
-  background-size: 200px 80px, cover;
-  background-repeat: repeat, no-repeat;
+  /* Subtle line pattern background */
+  background-color: #ffffff;
+  background-image: repeating-linear-gradient(
+      45deg,
+      #e5e5e5 0,
+      #e5e5e5 1px,
+      transparent 1px,
+      transparent 8px
+    );
+  background-size: auto;
+  background-repeat: repeat;
   background-attachment: fixed;
   color: #1f2937; /* text-gray-800 */
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 {% block content %}
 
 <!-- Landing Section -->
-<section class="min-h-[75vh] flex flex-col md:flex-row items-center justify-center bg-gradient-to-br from-slate-900 to-slate-700 text-white px-6 py-16 animate-fade-in" style="animation-delay: 0.2s;">
+<section class="min-h-[75vh] flex flex-col md:flex-row items-center justify-center bg-gradient-to-br from-white to-blue-50 text-gray-800 px-6 py-16 animate-fade-in" style="animation-delay: 0.2s;">
   <div class="w-full md:w-1/2 flex justify-center mb-10 md:mb-0">
     <img src="static/images/profile.jpg" alt="My Photo" class="w-48 h-48 md:w-56 md:h-56 rounded-full shadow-2xl border-4 border-white object-cover" />
   </div>
@@ -11,39 +11,39 @@
       Hi, I'm Jonan Harrewijn
     </h1>
     <p class="text-lg md:text-xl mb-2 max-w-xl">
-      <span class="text-gray-300">I’m a</span>
-      <span id="typing" class="font-semibold text-white"></span>
+      <span class="text-gray-500">I’m a</span>
+      <span id="typing" class="font-semibold text-blue-700"></span>
     </p>
-    <p class="text-base text-gray-300 max-w-xl leading-relaxed">
+    <p class="text-base text-gray-700 max-w-xl leading-relaxed">
       I build modern data platforms, dashboards, and data products using Microsoft Fabric, Azure, Power BI and Python. I help organizations turn raw data into strategic insight — fast, scalable, and secure.
     </p>
-    <div class="grid grid-cols-2 md:grid-cols-5 gap-6 mt-8 text-gray-300 text-xs md:text-sm">
+    <div class="grid grid-cols-2 md:grid-cols-5 gap-6 mt-8 text-gray-700 text-xs md:text-sm">
       <div class="flex flex-col items-center">
-        <svg class="h-8 w-8 mb-2 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
+        <svg class="h-8 w-8 mb-2 text-blue-700" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.737 5.1a3.375 3.375 0 0 1 2.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 0 1 .9 2.7m0 0a3 3 0 0 1-3 3m0 3h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Zm-3 6h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Z" />
         </svg>
         <span class="text-center">Data Platform Architect</span>
       </div>
       <div class="flex flex-col items-center">
-        <svg class="h-8 w-8 mb-2 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
+        <svg class="h-8 w-8 mb-2 text-blue-700" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
         </svg>
         <span class="text-center">Power BI Expert</span>
       </div>
       <div class="flex flex-col items-center">
-        <svg class="h-8 w-8 mb-2 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
+        <svg class="h-8 w-8 mb-2 text-blue-700" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
         </svg>
         <span class="text-center">ETL &amp; Pipeline Dev</span>
       </div>
       <div class="flex flex-col items-center">
-        <svg class="h-8 w-8 mb-2 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
+        <svg class="h-8 w-8 mb-2 text-blue-700" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z" />
         </svg>
         <span class="text-center">DevOps for Data</span>
       </div>
       <div class="flex flex-col items-center">
-        <svg class="h-8 w-8 mb-2 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
+        <svg class="h-8 w-8 mb-2 text-blue-700" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
         </svg>
         <span class="text-center">Data Governance Lead</span>
@@ -125,10 +125,10 @@
 
 
 <!-- Identity Section -->
-<section class="bg-slate-800 text-white py-16 px-6">
+<section class="bg-gradient-to-br from-white to-blue-50 text-gray-800 py-16 px-6">
   <div class="max-w-3xl mx-auto text-center space-y-4">
     <h2 class="text-2xl font-bold">Who I Am</h2>
-    <p class="text-base text-gray-300">Passionate about turning data into stories. I love clean design and helping organizations see the people behind the numbers.</p>
+    <p class="text-base text-gray-700">Passionate about turning data into stories. I love clean design and helping organizations see the people behind the numbers.</p>
   </div>
 </section>
 
@@ -208,15 +208,15 @@
 </section>
 
 <!-- Footer -->
-<footer class="bg-slate-800 text-white py-8 mt-16">
+<footer class="bg-gradient-to-br from-white to-blue-50 text-gray-800 py-8 mt-16">
   <div class="max-w-4xl mx-auto px-6 text-center">
     <p class="text-lg font-semibold mb-2">Let's connect</p>
     <p class="text-sm mb-4">
       📧 <a href="mailto:jonanharrewijn@hotmail.com" class="underline hover:text-blue-400">jonanharrewijn@hotmail.com</a><br>
       📱 <a href="tel:+31641270903" class="hover:text-blue-400">+31 6 41270903</a>
     </p>
-    <hr class="my-4 border-gray-600" />
-    <p class="text-xs text-gray-400">
+    <hr class="my-4 border-gray-300" />
+    <p class="text-xs text-gray-600">
       © {{ current_year }} Jonan Harrewijn. Built with Python, Jinja2 & 💙
     </p>
   </div>


### PR DESCRIPTION
## Summary
- lighten line pattern to very light grey
- adjust landing, identity and footer sections to white-to-blue gradient
- rebuild static site

## Testing
- `python build.py`

------
https://chatgpt.com/codex/tasks/task_e_6866479cc45483218973a5a4de641e2e