### PR TITLE
Apply unified background and add overlay

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,11 +10,11 @@
 <body>
   
 
-<section class="min-h-[75vh] flex flex-col md:flex-row items-center justify-center bg-gradient-to-br from-white to-blue-50 text-gray-800 px-6 py-16 animate-fade-in" style="animation-delay: 0.2s; background-image: url('static/images/background.webp'); background-size: cover; background-position: center;">
+<section class="min-h-[75vh] flex flex-col md:flex-row items-center justify-center text-gray-800 px-6 py-16 animate-fade-in text-outline">
   <div class="w-full md:w-1/2 flex justify-center mb-10 md:mb-0">
     <img src="static/images/profile.jpg" alt="My Photo" class="w-48 h-48 md:w-56 md:h-56 rounded-full shadow-2xl border-4 border-white object-cover" />
   </div>
-  <div class="w-full md:w-1/2 text-center md:text-left">
+  <div class="w-full md:w-1/2 text-center md:text-left overlay p-6 rounded-lg">
     <h1 class="text-4xl font-bold mb-3 leading-tight">
       Hi, I'm Jonan Harrewijn
     </h1>
@@ -153,8 +153,8 @@
 
 
 <!-- Identity Section -->
-<section class="bg-gradient-to-br from-white to-blue-50 text-gray-800 py-16 px-6 text-outline" style="background-image: url('static/images/background.webp'); background-size: cover; background-position: center;">
-  <div class="max-w-3xl mx-auto text-center space-y-4">
+<section class="py-16 px-6 text-outline overlay">
+  <div class="max-w-3xl mx-auto text-center space-y-4 overlay p-6 rounded-lg">
     <h2 class="text-2xl font-bold">Who I Am</h2>
     <p class="text-base text-gray-700">Husband. Father of two. Seasoned Microsoft Fabric Data Engineering &amp; BI Professional. With an MSc in Operations Management &amp; Logistics and a suite of Azure and Fabric certifications, I design reliable data ecosystems that deliver clear, actionable insights. From medallion-based pipelines to live Fabric reports, I help organizations make informed decisions with confidence. I balance technical excellence—crafting robust ETL processes and governed PySpark workflows—with a collaborative style, guiding teams toward shared success. I’m not just competent—I’m consistently raising the bar in Fabric data engineering and BI.</p>
   </div>
@@ -162,7 +162,7 @@
 
 
 <!-- Projects Carousel -->
-<section id="projects" class="bg-gradient-to-br from-white to-yellow-50 py-12 px-6 text-outline" style="background-image: url('static/images/background.webp'); background-size: cover; background-position: center;">
+<section id="projects" class="py-12 px-6 text-outline overlay">
   <h2 class="text-2xl font-bold mb-6 text-center">Where I've Worked</h2>
 
   <div class="relative">
@@ -300,7 +300,7 @@
 
 
 <!-- Certifications Section -->
-<section class="bg-gray-100 py-16 px-6 text-outline" style="background-image: url('static/images/background.webp'); background-size: cover; background-position: center;">
+<section class="py-16 px-6 text-outline overlay">
   <h2 class="text-2xl font-bold mb-10 text-center">Certifications</h2>
   <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-8 justify-items-center items-center">
     
@@ -343,7 +343,7 @@
 </section>
 
 <!-- Footer -->
-<footer class="bg-gradient-to-br from-white to-blue-50 text-gray-800 py-8 mt-16">
+<footer class="text-gray-800 py-8 mt-16 overlay">
   <div class="max-w-4xl mx-auto px-6 text-center">
     <p class="text-lg font-semibold mb-2">Let's connect</p>
     <p class="text-sm mb-4">

--- a/docs/static/style.css
+++ b/docs/static/style.css
@@ -1,10 +1,13 @@
 body {
-  /* Soft yellow gradient background */
-  background-image: linear-gradient(to bottom right, #ffffff, #fff9db);
-  background-attachment: fixed;
+  /* Continuous background image */
+  background: url('static/images/background.webp') center/cover fixed no-repeat;
   color: #1f2937; /* text-gray-800 */
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
 }
 .text-outline {
-  text-shadow: 0 1px 3px rgba(0,0,0,0.6);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+/* Semi-transparent background for text containers */
+.overlay {
+  background-color: rgba(255, 255, 255, 0.5);
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1,10 +1,13 @@
 body {
-  /* Soft yellow gradient background */
-  background-image: linear-gradient(to bottom right, #ffffff, #fff9db);
-  background-attachment: fixed;
+  /* Continuous background image */
+  background: url('static/images/background.webp') center/cover fixed no-repeat;
   color: #1f2937; /* text-gray-800 */
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
 }
 .text-outline {
-  text-shadow: 0 1px 3px rgba(0,0,0,0.6);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+/* Semi-transparent background for text containers */
+.overlay {
+  background-color: rgba(255, 255, 255, 0.5);
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% block content %}
 
-<section class="min-h-[75vh] flex flex-col md:flex-row items-center justify-center bg-gradient-to-br from-white to-blue-50 text-gray-800 px-6 py-16 animate-fade-in text-outline" style="animation-delay: 0.2s; background-image: url('static/images/background.webp'); background-size: cover; background-position: center;">
+<section class="min-h-[75vh] flex flex-col md:flex-row items-center justify-center text-gray-800 px-6 py-16 animate-fade-in text-outline">
   <div class="w-full md:w-1/2 flex justify-center mb-10 md:mb-0">
     <img src="static/images/profile.jpg" alt="My Photo" class="w-48 h-48 md:w-56 md:h-56 rounded-full shadow-2xl border-4 border-white object-cover" />
   </div>
-  <div class="w-full md:w-1/2 text-center md:text-left">
+  <div class="w-full md:w-1/2 text-center md:text-left overlay p-6 rounded-lg">
     <h1 class="text-4xl font-bold mb-3 leading-tight">
       Hi, I'm Jonan Harrewijn
     </h1>
@@ -124,8 +124,8 @@
 
 
 <!-- Identity Section -->
-<section class="bg-gradient-to-br from-white to-blue-50 text-gray-800 py-16 px-6 text-outline" style="background-image: url('static/images/background.webp'); background-size: cover; background-position: center;">
-  <div class="max-w-3xl mx-auto text-center space-y-4">
+<section class="py-16 px-6 text-outline overlay">
+  <div class="max-w-3xl mx-auto text-center space-y-4 overlay p-6 rounded-lg">
     <h2 class="text-2xl font-bold">Who I Am</h2>
     <p class="text-base text-gray-700">Husband. Father of two. Seasoned Microsoft Fabric Data Engineering &amp; BI Professional. With an MSc in Operations Management &amp; Logistics and a suite of Azure and Fabric certifications, I design reliable data ecosystems that deliver clear, actionable insights. From medallion-based pipelines to live Fabric reports, I help organizations make informed decisions with confidence. I balance technical excellence—crafting robust ETL processes and governed PySpark workflows—with a collaborative style, guiding teams toward shared success. I’m not just competent—I’m consistently raising the bar in Fabric data engineering and BI.</p>
   </div>
@@ -133,7 +133,7 @@
 
 
 <!-- Projects Carousel -->
-<section id="projects" class="bg-gradient-to-br from-white to-yellow-50 py-12 px-6 text-outline" style="background-image: url('static/images/background.webp'); background-size: cover; background-position: center;">
+<section id="projects" class="py-12 px-6 text-outline overlay">
   <h2 class="text-2xl font-bold mb-6 text-center">Where I've Worked</h2>
 
   <div class="relative">
@@ -194,7 +194,7 @@
 
 
 <!-- Certifications Section -->
-<section class="bg-gray-100 py-16 px-6 text-outline" style="background-image: url('static/images/background.webp'); background-size: cover; background-position: center;">
+<section class="py-16 px-6 text-outline overlay">
   <h2 class="text-2xl font-bold mb-10 text-center">Certifications</h2>
   <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-8 justify-items-center items-center">
     {% for cert in certifications %}
@@ -207,7 +207,7 @@
 </section>
 
 <!-- Footer -->
-<footer class="bg-gradient-to-br from-white to-blue-50 text-gray-800 py-8 mt-16">
+<footer class="text-gray-800 py-8 mt-16 overlay">
   <div class="max-w-4xl mx-auto px-6 text-center">
     <p class="text-lg font-semibold mb-2">Let's connect</p>
     <p class="text-sm mb-4">


### PR DESCRIPTION
## Summary
- use continuous background image from body CSS
- add `.overlay` helper for 50% white text backgrounds
- remove per-section background images and apply overlays
- rebuild `docs`

## Testing
- `python3 build.py`

------
https://chatgpt.com/codex/tasks/task_e_68666c1a248883219e7e5ca60ad97388