### PR TITLE
Remove text shadow style

### DIFF
--- a/docs/static/style.css
+++ b/docs/static/style.css
@@ -5,7 +5,6 @@ body {
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
 }
 .text-outline {
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
 }
 /* Semi-transparent background for text containers */
 .overlay {

--- a/static/style.css
+++ b/static/style.css
@@ -5,7 +5,6 @@ body {
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
 }
 .text-outline {
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
 }
 /* Semi-transparent background for text containers */
 .overlay {


### PR DESCRIPTION
## Summary
- remove global `text-shadow` effect

## Testing
- `python3 build.py`

------
https://chatgpt.com/codex/tasks/task_e_6866758d681083219e2ded0c6c8efc1b