### PR TITLE
Update hero and 'Who I Am' sections

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
 
 <section class="min-h-[75vh] flex flex-col md:flex-row items-center justify-center text-gray-800 px-6 py-16 animate-fade-in text-outline">
   <div class="w-full md:w-1/2 flex justify-center mb-10 md:mb-0">
-    <img src="static/images/profile.jpg" alt="My Photo" class="w-48 h-48 md:w-56 md:h-56 rounded-full shadow-2xl border-4 border-white object-cover" />
+    <img src="static/images/profile.jpg" alt="My Photo" class="w-64 h-64 md:w-80 md:h-80 rounded-full shadow-2xl border-4 border-white object-cover" />
   </div>
   <div class="w-full md:w-1/2 text-center md:text-left overlay p-6 rounded-lg">
     <h1 class="text-4xl font-bold mb-3 leading-tight">
@@ -153,10 +153,15 @@
 
 
 <!-- Identity Section -->
-<section class="py-16 px-6 text-outline overlay">
-  <div class="max-w-3xl mx-auto text-center space-y-4 overlay p-6 rounded-lg">
-    <h2 class="text-2xl font-bold">Who I Am</h2>
-    <p class="text-base text-gray-700">Husband. Father of two. Seasoned Microsoft Fabric Data Engineering &amp; BI Professional. With an MSc in Operations Management &amp; Logistics and a suite of Azure and Fabric certifications, I design reliable data ecosystems that deliver clear, actionable insights. From medallion-based pipelines to live Fabric reports, I help organizations make informed decisions with confidence. I balance technical excellence—crafting robust ETL processes and governed PySpark workflows—with a collaborative style, guiding teams toward shared success. I’m not just competent—I’m consistently raising the bar in Fabric data engineering and BI.</p>
+<section class="py-16 px-6 text-outline">
+  <div class="max-w-4xl mx-auto flex flex-col md:flex-row rounded-lg overflow-hidden">
+    <div class="md:w-1/2">
+      <img src="static/images/Persoonlijk.jpg" alt="Persoonlijk" class="w-full h-full object-cover" />
+    </div>
+    <div class="md:w-1/2 overlay whoiam-slash p-6 flex flex-col justify-center space-y-4">
+      <h2 class="text-2xl font-bold">Who I Am</h2>
+      <p class="text-base text-gray-700">Husband. Father of two. Seasoned Microsoft Fabric Data Engineering &amp; BI Professional. With an MSc in Operations Management &amp; Logistics and a suite of Azure and Fabric certifications, I design reliable data ecosystems that deliver clear, actionable insights. From medallion-based pipelines to live Fabric reports, I help organizations make informed decisions with confidence. I balance technical excellence—crafting robust ETL processes and governed PySpark workflows—with a collaborative style, guiding teams toward shared success. I’m not just competent—I’m consistently raising the bar in Fabric data engineering and BI.</p>
+    </div>
   </div>
 </section>
 

--- a/docs/static/style.css
+++ b/docs/static/style.css
@@ -10,3 +10,6 @@ body {
 .overlay {
   background-color: rgba(255, 255, 255, 0.5);
 }
+.whoiam-slash {
+  clip-path: polygon(8% 0, 100% 0, 100% 100%, 0 100%);
+}

--- a/static/style.css
+++ b/static/style.css
@@ -10,3 +10,6 @@ body {
 .overlay {
   background-color: rgba(255, 255, 255, 0.5);
 }
+.whoiam-slash {
+  clip-path: polygon(8% 0, 100% 0, 100% 100%, 0 100%);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 
 <section class="min-h-[75vh] flex flex-col md:flex-row items-center justify-center text-gray-800 px-6 py-16 animate-fade-in text-outline">
   <div class="w-full md:w-1/2 flex justify-center mb-10 md:mb-0">
-    <img src="static/images/profile.jpg" alt="My Photo" class="w-48 h-48 md:w-56 md:h-56 rounded-full shadow-2xl border-4 border-white object-cover" />
+    <img src="static/images/profile.jpg" alt="My Photo" class="w-64 h-64 md:w-80 md:h-80 rounded-full shadow-2xl border-4 border-white object-cover" />
   </div>
   <div class="w-full md:w-1/2 text-center md:text-left overlay p-6 rounded-lg">
     <h1 class="text-4xl font-bold mb-3 leading-tight">
@@ -124,10 +124,15 @@
 
 
 <!-- Identity Section -->
-<section class="py-16 px-6 text-outline overlay">
-  <div class="max-w-3xl mx-auto text-center space-y-4 overlay p-6 rounded-lg">
-    <h2 class="text-2xl font-bold">Who I Am</h2>
-    <p class="text-base text-gray-700">Husband. Father of two. Seasoned Microsoft Fabric Data Engineering &amp; BI Professional. With an MSc in Operations Management &amp; Logistics and a suite of Azure and Fabric certifications, I design reliable data ecosystems that deliver clear, actionable insights. From medallion-based pipelines to live Fabric reports, I help organizations make informed decisions with confidence. I balance technical excellence—crafting robust ETL processes and governed PySpark workflows—with a collaborative style, guiding teams toward shared success. I’m not just competent—I’m consistently raising the bar in Fabric data engineering and BI.</p>
+<section class="py-16 px-6 text-outline">
+  <div class="max-w-4xl mx-auto flex flex-col md:flex-row rounded-lg overflow-hidden">
+    <div class="md:w-1/2">
+      <img src="static/images/Persoonlijk.jpg" alt="Persoonlijk" class="w-full h-full object-cover" />
+    </div>
+    <div class="md:w-1/2 overlay whoiam-slash p-6 flex flex-col justify-center space-y-4">
+      <h2 class="text-2xl font-bold">Who I Am</h2>
+      <p class="text-base text-gray-700">Husband. Father of two. Seasoned Microsoft Fabric Data Engineering &amp; BI Professional. With an MSc in Operations Management &amp; Logistics and a suite of Azure and Fabric certifications, I design reliable data ecosystems that deliver clear, actionable insights. From medallion-based pipelines to live Fabric reports, I help organizations make informed decisions with confidence. I balance technical excellence—crafting robust ETL processes and governed PySpark workflows—with a collaborative style, guiding teams toward shared success. I’m not just competent—I’m consistently raising the bar in Fabric data engineering and BI.</p>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- enlarge the header portrait
- redesign the Who I Am panel with an angled divider and new photo
- include new style for the slash divider

## Testing
- `python3 build.py`

------
https://chatgpt.com/codex/tasks/task_e_68667d9211f88321972bcbc7f6ee15f2