### PR TITLE
Fix width and diagonal slash on Who I Am section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -154,11 +154,11 @@
 
 <!-- Identity Section -->
 <section class="py-16 px-6 text-outline">
-  <div class="max-w-4xl mx-auto flex flex-col md:flex-row rounded-lg overflow-hidden">
-    <div class="md:w-1/2">
+  <div class="max-w-6xl mx-auto flex flex-col md:flex-row rounded-lg overflow-hidden">
+    <div class="md:w-2/5">
       <img src="static/images/Persoonlijk.jpg" alt="Persoonlijk" class="w-full h-full object-cover" />
     </div>
-    <div class="md:w-1/2 overlay whoiam-slash p-6 flex flex-col justify-center space-y-4">
+    <div class="md:w-3/5 overlay whoiam-slash p-6 flex flex-col justify-center space-y-4">
       <h2 class="text-2xl font-bold">Who I Am</h2>
       <p class="text-base text-gray-700">Husband. Father of two. Seasoned Microsoft Fabric Data Engineering &amp; BI Professional. With an MSc in Operations Management &amp; Logistics and a suite of Azure and Fabric certifications, I design reliable data ecosystems that deliver clear, actionable insights. From medallion-based pipelines to live Fabric reports, I help organizations make informed decisions with confidence. I balance technical excellence—crafting robust ETL processes and governed PySpark workflows—with a collaborative style, guiding teams toward shared success. I’m not just competent—I’m consistently raising the bar in Fabric data engineering and BI.</p>
     </div>

--- a/docs/static/style.css
+++ b/docs/static/style.css
@@ -11,5 +11,5 @@ body {
   background-color: rgba(255, 255, 255, 0.5);
 }
 .whoiam-slash {
-  clip-path: polygon(8% 0, 100% 0, 100% 100%, 0 100%);
+  clip-path: polygon(20% 0, 100% 0, 100% 100%, 0 100%);
 }

--- a/static/style.css
+++ b/static/style.css
@@ -11,5 +11,5 @@ body {
   background-color: rgba(255, 255, 255, 0.5);
 }
 .whoiam-slash {
-  clip-path: polygon(8% 0, 100% 0, 100% 100%, 0 100%);
+  clip-path: polygon(20% 0, 100% 0, 100% 100%, 0 100%);
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -125,11 +125,11 @@
 
 <!-- Identity Section -->
 <section class="py-16 px-6 text-outline">
-  <div class="max-w-4xl mx-auto flex flex-col md:flex-row rounded-lg overflow-hidden">
-    <div class="md:w-1/2">
+  <div class="max-w-6xl mx-auto flex flex-col md:flex-row rounded-lg overflow-hidden">
+    <div class="md:w-2/5">
       <img src="static/images/Persoonlijk.jpg" alt="Persoonlijk" class="w-full h-full object-cover" />
     </div>
-    <div class="md:w-1/2 overlay whoiam-slash p-6 flex flex-col justify-center space-y-4">
+    <div class="md:w-3/5 overlay whoiam-slash p-6 flex flex-col justify-center space-y-4">
       <h2 class="text-2xl font-bold">Who I Am</h2>
       <p class="text-base text-gray-700">Husband. Father of two. Seasoned Microsoft Fabric Data Engineering &amp; BI Professional. With an MSc in Operations Management &amp; Logistics and a suite of Azure and Fabric certifications, I design reliable data ecosystems that deliver clear, actionable insights. From medallion-based pipelines to live Fabric reports, I help organizations make informed decisions with confidence. I balance technical excellence—crafting robust ETL processes and governed PySpark workflows—with a collaborative style, guiding teams toward shared success. I’m not just competent—I’m consistently raising the bar in Fabric data engineering and BI.</p>
     </div>


### PR DESCRIPTION
## Summary
- widen the Who I Am section so text has more space
- add a larger diagonal clip path for a slanted border between the image and the text

## Testing
- `python build.py`

------
https://chatgpt.com/codex/tasks/task_e_686680284dbc832189297e23662450c2