### PR TITLE
Fix who am I slash CSS

### DIFF
--- a/docs/static/style.css
+++ b/docs/static/style.css
@@ -11,5 +11,6 @@ body {
   background-color: rgba(255, 255, 255, 0.5);
 }
 .whoiam-slash {
-  clip-path: polygon(0 0, 100% 0, 100% 100%, 35% 100%);
+  /* Align the diagonal with the photo and keep text visible */
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 40% 100%);
 }

--- a/static/style.css
+++ b/static/style.css
@@ -11,6 +11,6 @@ body {
   background-color: rgba(255, 255, 255, 0.5);
 }
 .whoiam-slash {
-  clip-path: polygon(0 0, 100% 0, 100% 100%, 35% 100%);
-
+  /* Align the diagonal with the photo and keep text visible */
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 40% 100%);
 }


### PR DESCRIPTION
## Summary
- adjust CSS clip-path for the diagonal in the *Who I Am* section so it aligns with the photo and keeps the text intact
- rebuild static files

## Testing
- `python3 build.py`
- `curl -sI http://localhost:8000 | head`

------
https://chatgpt.com/codex/tasks/task_e_686683aa196c83218276e610c23e82dd