### PR TITLE
Remove diagonal slash from Who I Am section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -158,7 +158,7 @@
     <div class="md:w-[28.57%]">
       <img src="static/images/Persoonlijk.jpg" alt="Persoonlijk" class="w-full h-full object-cover" />
     </div>
-    <div class="md:w-[71.43%] overlay whoiam-slash p-6 flex flex-col justify-center space-y-4">
+    <div class="md:w-[71.43%] overlay p-6 flex flex-col justify-center space-y-4">
 
       <h2 class="text-2xl font-bold">Who I Am</h2>
       <p class="text-base text-gray-700">Husband. Father of two. Seasoned Microsoft Fabric Data Engineering &amp; BI Professional. With an MSc in Operations Management &amp; Logistics and a suite of Azure and Fabric certifications, I design reliable data ecosystems that deliver clear, actionable insights. From medallion-based pipelines to live Fabric reports, I help organizations make informed decisions with confidence. I balance technical excellence—crafting robust ETL processes and governed PySpark workflows—with a collaborative style, guiding teams toward shared success. I’m not just competent—I’m consistently raising the bar in Fabric data engineering and BI.</p>

--- a/docs/static/style.css
+++ b/docs/static/style.css
@@ -10,7 +10,3 @@ body {
 .overlay {
   background-color: rgba(255, 255, 255, 0.5);
 }
-.whoiam-slash {
-  /* Align the diagonal with the photo and keep text visible */
-  clip-path: polygon(0 0, 100% 0, 100% 100%, 40% 100%);
-}

--- a/static/style.css
+++ b/static/style.css
@@ -10,7 +10,3 @@ body {
 .overlay {
   background-color: rgba(255, 255, 255, 0.5);
 }
-.whoiam-slash {
-  /* Align the diagonal with the photo and keep text visible */
-  clip-path: polygon(0 0, 100% 0, 100% 100%, 40% 100%);
-}

--- a/templates/index.html
+++ b/templates/index.html
@@ -129,7 +129,7 @@
     <div class="md:w-[28.57%]">
       <img src="static/images/Persoonlijk.jpg" alt="Persoonlijk" class="w-full h-full object-cover" />
     </div>
-    <div class="md:w-[71.43%] overlay whoiam-slash p-6 flex flex-col justify-center space-y-4">
+    <div class="md:w-[71.43%] overlay p-6 flex flex-col justify-center space-y-4">
 
       <h2 class="text-2xl font-bold">Who I Am</h2>
       <p class="text-base text-gray-700">Husband. Father of two. Seasoned Microsoft Fabric Data Engineering &amp; BI Professional. With an MSc in Operations Management &amp; Logistics and a suite of Azure and Fabric certifications, I design reliable data ecosystems that deliver clear, actionable insights. From medallion-based pipelines to live Fabric reports, I help organizations make informed decisions with confidence. I balance technical excellence—crafting robust ETL processes and governed PySpark workflows—with a collaborative style, guiding teams toward shared success. I’m not just competent—I’m consistently raising the bar in Fabric data engineering and BI.</p>


### PR DESCRIPTION
## Summary
- remove unused whoiam-slash class and CSS rule
- rebuild docs without the diagonal clip-path

## Testing
- `python3 build.py`


------
https://chatgpt.com/codex/tasks/task_e_6866859b8e508321a4869dd81ece92e0